### PR TITLE
Fix outdated path comments

### DIFF
--- a/app/Blog/Podcast/Podcast
+++ b/app/Blog/Podcast/Podcast
@@ -1,4 +1,4 @@
-// /app/blog/page.tsx
+// Path: app/Blog/Podcast/Podcast – renders the /blog/podcast route
 export default function BlogPage() {
   return (
     <section className="py-24 px-4 max-w-4xl mx-auto">

--- a/app/Calendar/Calendar
+++ b/app/Calendar/Calendar
@@ -1,4 +1,4 @@
-// /app/calendar/page.tsx
+// Path: app/Calendar/Calendar – renders the /calendar route
 export default function CalendarPage() {
   return (
     <section className="py-24 px-4 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- update comment in Calendar page to show actual file path
- update comment in Blog/Podcast page to show actual file path

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a09847c608327958edad98f45df3d