### PR TITLE
Add Jest and RTL test suite for ChatbotWidget

### DIFF
--- a/__tests__/ChatbotWidget.test.tsx
+++ b/__tests__/ChatbotWidget.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ChatbotWidget from '../components/ChatbotWidget'
+
+describe('ChatbotWidget', () => {
+  test('chat button toggles widget open and closed', async () => {
+    render(<ChatbotWidget />)
+    const chatButton = screen.getByRole('button', { name: /chat with bachata ai/i })
+    // initially closed
+    expect(screen.queryByText(/start chat/i)).not.toBeInTheDocument()
+    await userEvent.click(chatButton)
+    expect(screen.getByText(/start chat/i)).toBeInTheDocument()
+    await userEvent.click(chatButton)
+    expect(screen.queryByText(/start chat/i)).not.toBeInTheDocument()
+  })
+
+  test('shows Typing indicator while message is being sent', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve({ ok: true, json: async () => ({ reply: 'Hello' }) }),
+              50
+            )
+          )
+      )
+    ;(globalThis as any).fetch = fetchMock
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      value: jest.fn(),
+      writable: true,
+    })
+
+    render(<ChatbotWidget />)
+    const user = userEvent.setup()
+
+    // open and capture lead to reach chat view
+    await user.click(screen.getByRole('button', { name: /chat with bachata ai/i }))
+    await user.type(screen.getByPlaceholderText(/your name/i), 'Jane')
+    await user.type(screen.getByPlaceholderText(/your email/i), 'jane@example.com')
+    await user.click(screen.getByRole('button', { name: /start chat/i }))
+
+    // send a message
+    await user.type(screen.getByPlaceholderText(/type your question/i), 'Hi')
+    await user.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(screen.getByText(/typing/i)).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText(/typing/i)).not.toBeInTheDocument())
+
+    fetchMock.mockRestore()
+  })
+})

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript',
+  ],
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  transform: {
+    '^.+\\.(t|j)sx?$': 'babel-jest',
+  },
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "15.3.3",
@@ -14,11 +15,19 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.27.2",
+    "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.21",
+    "jest": "^30.0.2",
+    "jest-environment-jsdom": "^30.0.2",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- add Jest + React Testing Library setup
- configure Babel for tests
- add basic ChatbotWidget tests
- expose `test` script in `package.json`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a0985fea883279fe4a1fcdce4bed3